### PR TITLE
Clean up code and fix bugs

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,22 +1,52 @@
-local function clearExcessMobs(maxMobs)
+local config = {}
+local settingNamePrefix = "mob_limiter."
+
+local function setting(name, default)
+    local value = tonumber(minetest.settings:get(settingNamePrefix..name))
+    if value == nil then
+        value = default
+    end
+    config[name] = value
+end
+
+setting("max_mobs", 3)
+setting("search_distance", 35)
+setting("scan_period", 60)
+
+local function isRemovableMob(obj)
+    local ent = obj:get_luaentity()
+
+    -- mobs mod
+    if ent and ent._cmi_is_mob and not ent.tamed then
+        return true
+    end
+
+    -- creatura
+    -- FIXME: figure out how to exclude tamed mobs or things that aren't mobs
+    -- if ent and ent._creatura_mob and TODO then
+    --     return true
+    -- end
+
+    return false
+end
+
+local function clearExcessMobs()
     local players = minetest.get_connected_players()
 
     for _, player in ipairs(players) do
         local pos = player:get_pos()
-        local objs = minetest.get_objects_inside_radius(pos, 35)
+        local objs = minetest.get_objects_inside_radius(pos, config.search_distance)
         local mobsCount = 0  -- Counter for mobs found around the player
 
         -- Count the number of mobs around the player
         for _, obj in ipairs(objs) do
-            local ent = obj:get_luaentity()
-
-            if ent and ent._cmi_is_mob and not ent.tamed then
+            if isRemovableMob(obj) then
                 mobsCount = mobsCount + 1
             end
         end
 
         -- Check if the number of mobs found exceeds the maximum allowed
-        local excessMobs = mobsCount - maxMobs
+        local excessMobs = mobsCount - config.max_mobs
         if excessMobs > 0 then
             local removedCount = 0
 
@@ -26,9 +56,7 @@ local function clearExcessMobs(maxMobs)
                     break  -- Exit loop if enough mobs have been removed
                 end
 
-                local ent = obj:get_luaentity()
-
-                if ent and ent._cmi_is_mob and not ent.tamed then
+                if isRemovableMob(obj) then
                     obj:remove()  -- Remove the mob object directly
                     removedCount = removedCount + 1
                 end
@@ -39,14 +67,13 @@ local function clearExcessMobs(maxMobs)
     end
 end
 
--- Adjust this value according to your desired maximum number of mobs allowed
-local maxMobsAllowed = 3
-
+local timeSinceLastScan = 0
 -- Schedule the function to be called automatically at a regular interval
 minetest.register_globalstep(function(dtime)
-    -- Adjust the interval based on your needs; this runs every 60 seconds
-    if math.floor(minetest.get_gametime() % 60) == 0 then
-        clearExcessMobs(maxMobsAllowed)
+    timeSinceLastScan = timeSinceLastScan + dtime
+    if timeSinceLastScan >= config.scan_period then
+        timeSinceLastScan = 0
+        clearExcessMobs()
     end
 end)
 

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,8 @@
+# Maximum number of mobs allowed around any player
+mob_limiter.max_mobs (Maximum number of mobs) int 3 0 100
+
+# Distance to search around players for mobs
+mob_limiter.search_distance (Search distance) float 35 1 200
+
+# Time between scans for mobs (in seconds)
+mob_limiter.scan_period (Scan period) float 60 0.1 3600


### PR DESCRIPTION
Moves settings to use minetest settings for easier management by user.

Fixes bug where it will scan every tick when the current time ends in `*:00` (e.g. if running at 20 ticks per second, it would scan 20 times in that one second) instead of just once every 60s.

Factors out removable-mob detection into a separate function and starts adding commented code for creatura support.